### PR TITLE
Giant amount of general performance improvements

### DIFF
--- a/lib/archetype.dart
+++ b/lib/archetype.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 /// Used in the Realm to speed up queries for nodes
 class Archetype {
   static List<Archetype> allCombinations(Iterable<Type> types) {
@@ -28,7 +30,20 @@ class Archetype {
     return archetypes;
   }
 
+  static HashMap<Type, int> _typeToIndex = HashMap<Type, int>();
+  static int toIndex(Type type) {
+    if (_typeToIndex.containsKey(type)) {
+      return _typeToIndex[type]!;
+    }
+    var index = _typeToIndex.length;
+    _typeToIndex[type] = index;
+    return index;
+  }
+
   var types = <Type>[];
+  var typesAsString = <String>[];
+  var typesAsIndices = <int>[];
+  int typesSum = 0;
   late final String name;
 
   get length => types.length;
@@ -38,12 +53,40 @@ class Archetype {
     sorted.sort((a, b) => a.toString().compareTo(b.toString()));
     this.types = sorted;
     name = sorted.join(',');
+    typesAsString = sorted.map((e) => e.toString()).toList();
+    typesAsIndices = sorted.map((e) => toIndex(e)).toList();
+    typesSum = typesAsIndices.fold(0, (a, b) => a + b);
   }
 
-  bool includes(Type type) => types.contains(type);
-  bool includesAll(Iterable<Type> types) => types.every(includes);
-  bool includesOther(Archetype other) => includesAll(other.types);
-  bool includesAny(Iterable<Type> types) => types.any(includes);
+  bool includesIndex(int index) => typesAsIndices.contains(index);
+  bool includes(Type type) => includesIndex(toIndex(type));
+  bool includesAllIndices(List<int> indices) {
+    final length = indices.length;
+    for (var i = 0; i < length; i++) {
+      if (typesAsIndices.contains(indices[i]) == false) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool includesAll(Iterable<Type> types) =>
+      includesAllIndices(types.map((e) => toIndex(e)).toList());
+  bool includesOther(Archetype other) =>
+      includesAllIndices(other.typesAsIndices);
+  bool includesAnyIndices(List<int> indices) {
+    final length = indices.length;
+    for (var i = 0; i < length; i++) {
+      if (typesAsIndices.contains(indices[i])) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool includesAny(Iterable<Type> types) =>
+      includesAnyIndices(types.map((e) => toIndex(e)).toList());
+
   Archetype concat(Archetype other) {
     var types = this.types + other.types;
     types = types.toSet().toList();
@@ -60,10 +103,11 @@ class Archetype {
   bool operator ==(other) {
     if (other is! Archetype) return false;
     var equals = false;
-    if (other.types.length == types.length) {
+    if (typesSum == other.typesSum) {
       equals = true;
-      for (var i = 0; i < types.length; i++) {
-        if (other.types[i] != types[i]) {
+      final length = types.length;
+      for (var i = 0; i < length; i++) {
+        if (other.typesAsIndices[i] != typesAsIndices[i]) {
           equals = false;
           break;
         }

--- a/lib/filter.dart
+++ b/lib/filter.dart
@@ -7,36 +7,49 @@ abstract class AFilter {
 
 /// Checks if all types are included
 class Has extends AFilter {
-  final Iterable<Type> components;
-  Has(this.components);
+  final List<Type> components;
+  late final List<int> componentsAsIndices;
+  Has(this.components) {
+    componentsAsIndices = components.map((e) => Archetype.toIndex(e)).toList();
+  }
   @override
-  bool matches(Archetype archetype) => archetype.includesAll(components);
+  bool matches(Archetype archetype) =>
+      archetype.includesAllIndices(componentsAsIndices);
 }
 
 /// Check if at least one type is inlcuded
 class HasAny extends AFilter {
-  final Iterable<Type> components;
-  HasAny(this.components);
+  final List<Type> components;
+  late final List<int> componentsAsIndices;
+  HasAny(this.components) {
+    componentsAsIndices = components.map((e) => Archetype.toIndex(e)).toList();
+  }
   @override
-  bool matches(Archetype archetype) => archetype.includesAny(components);
+  bool matches(Archetype archetype) =>
+      archetype.includesAnyIndices(componentsAsIndices);
 }
 
 /// Check that none of the types are included
 class Without extends AFilter {
-  final Iterable<Type> components;
-  Without(this.components);
+  final List<Type> components;
+  late final List<int> componentsAsIndices;
+  Without(this.components) {
+    componentsAsIndices = components.map((e) => Archetype.toIndex(e)).toList();
+  }
   @override
   bool matches(Archetype archetype) =>
-      archetype.includesAny(components) == false;
+      archetype.includesAnyIndices(componentsAsIndices) == false;
 }
 
 /// Logical and multiple filters together
 class And extends AFilter {
-  final Iterable<AFilter> filters;
+  final List<AFilter> filters;
   And(this.filters);
   @override
   bool matches(Archetype archetype) {
-    for (var filter in filters) {
+    final length = filters.length;
+    for (var i = 0; i < length; i++) {
+      final filter = filters[i];
       if (filter.matches(archetype) == false) {
         return false;
       }
@@ -47,11 +60,13 @@ class And extends AFilter {
 
 /// Logical Or multiple filters together
 class Or extends AFilter {
-  final Iterable<AFilter> filters;
+  final List<AFilter> filters;
   Or(this.filters);
   @override
   bool matches(Archetype archetype) {
-    for (var filter in filters) {
+    final length = filters.length;
+    for (var i = 0; i < length; i++) {
+      final filter = filters[i];
       if (filter.matches(archetype)) {
         return true;
       }

--- a/lib/log.dart
+++ b/lib/log.dart
@@ -1,0 +1,95 @@
+import 'dart:collection';
+
+import 'package:backbone/realm.dart';
+import 'package:backbone/system.dart';
+import 'package:flutter/widgets.dart';
+
+class SystemPerformanceLog {
+  final String column;
+  final String? parent;
+  int value;
+
+  SystemPerformanceLog(this.column, this.parent, this.value);
+}
+
+class ProcessedSystemPerformanceLog {
+  final String column;
+  final String? parent;
+  int value;
+
+  ProcessedSystemPerformanceLog(this.column, this.value, {this.parent});
+}
+
+class LogStopwatch {
+  final DateTime startTime = DateTime.now();
+  int stop() => DateTime.now().difference(startTime).inMicroseconds;
+}
+
+class Log {
+  // Specific metrics for low-cost logging
+  static int transformQueryTime = 0;
+  static int transformBodyTime = 0;
+
+  // Performance logging
+  static HashMap<String, SystemPerformanceLog> _systemPerformanceLog =
+      HashMap();
+
+  static void logPerformance(String category, String value) {
+    debugPrint('prefmon:$category->$value:prefmon');
+  }
+
+  static void logSystemPerformance(
+      String column, String? parentColumn, int value,
+      {int? frame}) {
+    final key = "$parentColumn->$column";
+    final existing = _systemPerformanceLog[key];
+    if (existing != null) {
+      existing.value += value;
+    } else {
+      _systemPerformanceLog[key] =
+          SystemPerformanceLog(column, parentColumn, value);
+    }
+  }
+
+  static void processPerformanceLogs() {
+    // Gather everything up
+    final processed = <String, ProcessedSystemPerformanceLog>{};
+    for (final log in _systemPerformanceLog.values) {
+      final key = "${log.parent}->${log.column}";
+      if (processed.containsKey(key)) {
+        processed[key]!.value += log.value;
+      } else {
+        processed[key] = ProcessedSystemPerformanceLog(log.column, log.value,
+            parent: log.parent);
+      }
+    }
+
+    // Turn specific metrics into the same format
+    processed["transformSystem->query"] = ProcessedSystemPerformanceLog(
+        "query", transformQueryTime,
+        parent: "transformSystem");
+    processed["transformSystem->body"] = ProcessedSystemPerformanceLog(
+        "body", transformBodyTime,
+        parent: "transformSystem");
+
+    // Send it
+    for (final log in processed.values) {
+      logPerformance("Systems",
+          "${log.column},${log.parent},${log.value},${Realm.globalFrame}");
+    }
+
+    // Clear
+    _systemPerformanceLog = HashMap();
+    transformQueryTime = 0;
+    transformBodyTime = 0;
+  }
+
+  static final RegExp systemMatcher = RegExp('\'(.*?)\'');
+  static String getSystemName(System system) {
+    final match = systemMatcher.firstMatch(system.toString());
+    if (match != null) {
+      return match.group(1)!;
+    }
+    return 'Unknown System';
+  }
+}

--- a/lib/prelude/transform.dart
+++ b/lib/prelude/transform.dart
@@ -52,7 +52,13 @@ class TransformTrait extends ATrait {
 /// - size
 /// - anchor
 void transformSystem(Realm realm) {
+  final queryStartTime = DateTime.now();
   final realmQuery = realm.query(Has([TransformTrait]));
+  final queryEndTime = DateTime.now();
+  final queryTime = queryEndTime.difference(queryStartTime).inMicroseconds;
+  Realm.logSystemPerformance(
+      "query", Realm.getSystemName(transformSystem), queryTime);
+
   for (final node in realmQuery) {
     if (node is PositionNode) {
       final transform = node.get<TransformTrait>();

--- a/lib/prelude/transform.dart
+++ b/lib/prelude/transform.dart
@@ -52,12 +52,12 @@ class TransformTrait extends ATrait {
 /// - size
 /// - anchor
 void transformSystem(Realm realm) {
-  final queryStartTime = DateTime.now();
+//  final queryStartTime = DateTime.now();
   final realmQuery = realm.query(Has([TransformTrait]));
-  final queryEndTime = DateTime.now();
-  final queryTime = queryEndTime.difference(queryStartTime).inMicroseconds;
-  Realm.logSystemPerformance(
-      "query", Realm.getSystemName(transformSystem), queryTime);
+// final queryEndTime = DateTime.now();
+//  final queryTime = queryEndTime.difference(queryStartTime).inMicroseconds;
+  // Realm.logSystemPerformance(
+  //     "query", Realm.getSystemName(transformSystem), queryTime);
 
   for (final node in realmQuery) {
     if (node is PositionNode) {

--- a/lib/prelude/transform.dart
+++ b/lib/prelude/transform.dart
@@ -1,5 +1,6 @@
 import 'package:backbone/builders.dart';
 import 'package:backbone/filter.dart';
+import 'package:backbone/log.dart';
 import 'package:backbone/node.dart';
 import 'package:backbone/position_node.dart';
 import 'package:backbone/trait.dart';
@@ -20,12 +21,67 @@ void transformPlugin(RealmBuilder builder) {
 }
 
 class TransformTrait extends ATrait {
-  Vector2 position = Vector2.zero();
-  Vector2 scale = Vector2.all(1.0);
-  Vector2 size = Vector2.zero();
-  double rotation = 0.0;
-  Anchor anchor = Anchor.topLeft;
+  Vector2 _position = Vector2.zero();
+  Vector2 _scale = Vector2.all(1.0);
+  Vector2 _size = Vector2.zero();
+  double _rotation = 0.0;
+  Anchor _anchor = Anchor.topLeft;
   bool positionSet = false;
+
+  // Wrappers and dirty flags
+  void setDirty({bool value = false}) {
+    _dirtyPosition = value;
+  }
+
+  // -- position
+  bool _dirtyPosition = false;
+  Vector2 get position => _position;
+  set position(Vector2 value) {
+    if (_position != value) {
+      _position = value;
+      _dirtyPosition = true;
+    }
+  }
+
+  // -- scale
+  bool _dirtyScale = false;
+  Vector2 get scale => _scale;
+  set scale(Vector2 value) {
+    if (_scale != value) {
+      _scale = value;
+      _dirtyScale = true;
+    }
+  }
+
+  // -- rotation
+  bool _dirtyRotation = false;
+  double get rotation => _rotation;
+  set rotation(double value) {
+    if (_rotation != value) {
+      _rotation = value;
+      _dirtyRotation = true;
+    }
+  }
+
+  // -- size
+  bool _dirtySize = false;
+  Vector2 get size => _size;
+  set size(Vector2 value) {
+    if (_size != value) {
+      _size = value;
+      _dirtySize = true;
+    }
+  }
+
+  // -- anchor
+  bool _dirtyAnchor = false;
+  Anchor get anchor => _anchor;
+  set anchor(Anchor value) {
+    if (_anchor != value) {
+      _anchor = value;
+      _dirtyAnchor = true;
+    }
+  }
 
   Rect get rect => Rect.fromLTWH(position.x - anchor.x * size.x,
       position.y - anchor.y * size.y, size.x, size.y);
@@ -52,32 +108,32 @@ class TransformTrait extends ATrait {
 /// - size
 /// - anchor
 void transformSystem(Realm realm) {
-  final queryStartTime = DateTime.now();
+  final queryWatch = LogStopwatch();
   final realmQuery = realm.query(Has([TransformTrait]));
-  final queryEndTime = DateTime.now();
-  final queryTime = queryEndTime.difference(queryStartTime).inMicroseconds;
-  Realm.logSystemPerformance(
-      "query", Realm.getSystemName(transformSystem), queryTime);
+  Log.transformQueryTime += queryWatch.stop();
 
   for (final node in realmQuery) {
+    final bodyWatch = LogStopwatch();
     if (node is PositionNode) {
       final transform = node.get<TransformTrait>();
-      if (node.position != transform.position) {
+      if (transform._dirtyPosition) {
         node.position = transform.position;
       }
-      if (node.scale != transform.scale) {
+      if (transform._dirtyScale) {
         node.scale = transform.scale;
       }
-      if (node.angle != transform.rotation) {
+      if (transform._dirtyRotation) {
         node.angle = transform.rotation;
       }
-      if (node.size != transform.size) {
+      if (transform._dirtySize) {
         node.size = transform.size;
       }
-      if (node.anchor != transform.anchor) {
+      if (transform._dirtyAnchor) {
         node.anchor = transform.anchor;
       }
       transform.positionSet = true;
+      transform.setDirty(value: false);
     }
+    Log.transformBodyTime += bodyWatch.stop();
   }
 }

--- a/lib/prelude/transform.dart
+++ b/lib/prelude/transform.dart
@@ -31,6 +31,10 @@ class TransformTrait extends ATrait {
   // Wrappers and dirty flags
   void setDirty({bool value = false}) {
     _dirtyPosition = value;
+    _dirtyScale = value;
+    _dirtySize = value;
+    _dirtyRotation = value;
+    _dirtyAnchor = value;
   }
 
   // -- position

--- a/lib/prelude/transform.dart
+++ b/lib/prelude/transform.dart
@@ -30,60 +30,60 @@ class TransformTrait extends ATrait {
 
   // Wrappers and dirty flags
   void setDirty({bool value = false}) {
-    _dirtyPosition = value;
-    _dirtyScale = value;
-    _dirtySize = value;
-    _dirtyRotation = value;
-    _dirtyAnchor = value;
+    dirtyPosition = value;
+    dirtyScale = value;
+    dirtySize = value;
+    dirtyRotation = value;
+    dirtyAnchor = value;
   }
 
   // -- position
-  bool _dirtyPosition = false;
+  bool dirtyPosition = false;
   Vector2 get position => _position;
   set position(Vector2 value) {
     if (_position != value) {
       _position = value;
-      _dirtyPosition = true;
+      dirtyPosition = true;
     }
   }
 
   // -- scale
-  bool _dirtyScale = false;
+  bool dirtyScale = false;
   Vector2 get scale => _scale;
   set scale(Vector2 value) {
     if (_scale != value) {
       _scale = value;
-      _dirtyScale = true;
+      dirtyScale = true;
     }
   }
 
   // -- rotation
-  bool _dirtyRotation = false;
+  bool dirtyRotation = false;
   double get rotation => _rotation;
   set rotation(double value) {
     if (_rotation != value) {
       _rotation = value;
-      _dirtyRotation = true;
+      dirtyRotation = true;
     }
   }
 
   // -- size
-  bool _dirtySize = false;
+  bool dirtySize = false;
   Vector2 get size => _size;
   set size(Vector2 value) {
     if (_size != value) {
       _size = value;
-      _dirtySize = true;
+      dirtySize = true;
     }
   }
 
   // -- anchor
-  bool _dirtyAnchor = false;
+  bool dirtyAnchor = false;
   Anchor get anchor => _anchor;
   set anchor(Anchor value) {
     if (_anchor != value) {
       _anchor = value;
-      _dirtyAnchor = true;
+      dirtyAnchor = true;
     }
   }
 
@@ -120,19 +120,19 @@ void transformSystem(Realm realm) {
     final bodyWatch = LogStopwatch();
     if (node is PositionNode) {
       final transform = node.get<TransformTrait>();
-      if (transform._dirtyPosition) {
+      if (transform.dirtyPosition) {
         node.position = transform.position;
       }
-      if (transform._dirtyScale) {
+      if (transform.dirtyScale) {
         node.scale = transform.scale;
       }
-      if (transform._dirtyRotation) {
+      if (transform.dirtyRotation) {
         node.angle = transform.rotation;
       }
-      if (transform._dirtySize) {
+      if (transform.dirtySize) {
         node.size = transform.size;
       }
-      if (transform._dirtyAnchor) {
+      if (transform.dirtyAnchor) {
         node.anchor = transform.anchor;
       }
       transform.positionSet = true;

--- a/lib/realm.dart
+++ b/lib/realm.dart
@@ -346,8 +346,10 @@ class Realm extends Component with HasGameRef {
   void renderTree(Canvas canvas) {
     final renderStart = DateTime.now();
     super.renderTree(canvas);
-    Log.logPerformance('Render',
-        DateTime.now().difference(renderStart).inMilliseconds.toString());
+    if (logPerformanceData) {
+      Log.logPerformance('Render',
+          DateTime.now().difference(renderStart).inMilliseconds.toString());
+    }
   }
 
   // Update Loop
@@ -404,11 +406,12 @@ class Realm extends Component with HasGameRef {
     // Clear the inputs
     final input = getResource<Input>();
     input.clear();
-    Log.logPerformance('Update',
-        DateTime.now().difference(updateStart).inMilliseconds.toString());
-
-    // Update the frame count and try to process the log
-    frame += 1;
-    Log.processPerformanceLogs();
+    if (logPerformanceData) {
+      Log.logPerformance('Update',
+          DateTime.now().difference(updateStart).inMilliseconds.toString());
+      // Update the frame count and try to process the log
+      frame += 1;
+      Log.processPerformanceLogs();
+    }
   }
 }

--- a/prefmon/lib/core/backbone_worker.dart
+++ b/prefmon/lib/core/backbone_worker.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter/widgets.dart';
 import 'package:prefmon/core/settings.dart';
 
 abstract class PrefMonEvent {}

--- a/prefmon/lib/core/backbone_worker.dart
+++ b/prefmon/lib/core/backbone_worker.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/widgets.dart';
 import 'package:prefmon/core/settings.dart';
 
 abstract class PrefMonEvent {}
@@ -43,7 +44,7 @@ class BackboneWorker {
       "flutter",
       cmdParts.sublist(1),
       workingDirectory: workingDir,
-      runInShell: Platform.isWindows,
+      runInShell: Platform.isWindows || Platform.isLinux,
     );
     _flutterRunner.exitCode.then((value) => callback?.call(Stopped()));
     final encoding = utf8.decoder;

--- a/prefmon/lib/widget/statistics.dart
+++ b/prefmon/lib/widget/statistics.dart
@@ -194,7 +194,7 @@ class _StatisticsState extends State<Statistics> {
                     return _lastData[index].toString();
                   },
                   textStyle: Theme.of(context).textTheme.bodySmall,
-                  horizontalAxisStep: 100,
+                  horizontalAxisStep: 10,
                 ),
               ],
               foregroundDecorations: [

--- a/test/world_test.dart
+++ b/test/world_test.dart
@@ -165,6 +165,7 @@ void main() {
         }
         return false;
       }).build();
+      realm.logPerformanceData = true;
       realm.pushMessage(RealmTestMessage(1));
       realm.update(0.0);
       realm.update(0.0);


### PR DESCRIPTION
* Don't use `Type` directly whenever possible, convert to an efficient number representation
* Add multiple "alternative" data-structures for specific situations
* Convert more `foreach` loops to `for` loops
* Improve the "prefmon" (simpler now, allows showing "child" data)

On my system it meant reducing query times from ~300 microseconds to ~100!