### PR TITLE
Fix system logging names

### DIFF
--- a/.github/workflows/build_check_test.yml
+++ b/.github/workflows/build_check_test.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Restore packages
         run: | 
           flutter pub get
-          flutter pub get prefmon
       # Run tests
       - name: Run flutter tests
         run: |

--- a/example/lib/game.dart
+++ b/example/lib/game.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:backbone/backbone.dart';
 import 'package:backbone/builders.dart';
+import 'package:backbone/logging/log.dart';
 import 'package:backbone/realm_mixin.dart';
 import 'package:example/bouncer.dart';
 import 'package:example/bouncer_counter.dart';
@@ -10,6 +11,7 @@ import 'package:example/systems.dart';
 import 'package:flame/events.dart';
 import 'package:flame/experimental.dart';
 import 'package:flame/game.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:perfmon_logger/perfmon_logger.dart';
 
@@ -24,6 +26,10 @@ class MainGame extends FlameGame
         HasRealm {
   @override
   Future<void> onLoad() async {
+    Log? logger;
+    if (kProfileMode) {
+      logger = PerfmonLogger();
+    }
     realm = RealmBuilder()
         .withPlugin(defaultPlugin)
         .withTrait(BouncerTrait)
@@ -36,7 +42,7 @@ class MainGame extends FlameGame
         .withSystem(deleteRemoveSystem)
         .withMessageSystem(removeBounceMessageSystem)
         .withMessageSystem(resizeMessageSystem)
-        .build(realmLogger: PerfmonLogger());
+        .build(realmLogger: logger);
     add(realm);
 
     // Generate some bouncers

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,7 +11,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  cupertino_icons: ^1.0.2
   flame: 1.6.0
   backbone:
     git:

--- a/lib/system.dart
+++ b/lib/system.dart
@@ -24,7 +24,9 @@ String getSystemName(System system) {
           .trim()
           .split("(")[0]
           .trim();
-    } catch (ex) {}
+    } catch (ex) {
+      // Not important fallback below will take care
+    }
   }
   final match = systemNameMatcher.firstMatch(system.toString());
   if (match != null) {

--- a/lib/system.dart
+++ b/lib/system.dart
@@ -15,7 +15,7 @@ typedef MessageSystem = bool Function(Realm realm, AMessage message);
 final RegExp systemNameMatcher = RegExp('\'(.*?)\'');
 
 String getSystemName(System system) {
-  if (kIsWeb) {
+  if (kIsWeb && kDebugMode) {
     try {
       return system
           .toString()
@@ -24,15 +24,11 @@ String getSystemName(System system) {
           .trim()
           .split("(")[0]
           .trim();
-    } catch (ex) {
-      debugPrint("Error getting sysname: $ex");
-    }
-  } else {
-    final match = systemNameMatcher.firstMatch(system.toString());
-    if (match != null) {
-      return match.group(1)!;
-    }
+    } catch (ex) {}
   }
-
+  final match = systemNameMatcher.firstMatch(system.toString());
+  if (match != null) {
+    return match.group(1)!;
+  }
   return 'Unknown System';
 }


### PR DESCRIPTION
Flutter web has different behaviors for profiling and debug, now perfmon gets the correct names no matter the mode